### PR TITLE
travis-ci: Fix kubecfg install location and permissions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,9 @@ before_install:
 install:
   - go build -i ./...
   - >-
-    wget -O kubecfg
+    wget -O $GOPATH/bin/kubecfg
     https://github.com/ksonnet/kubecfg/releases/download/v0.2.0/kubecfg-$(go env GOOS)-$(go env GOARCH)
+  - chmod +x $GOPATH/bin/kubecfg
   - git clone --depth=1 https://github.com/ksonnet/ksonnet-lib.git
   - export KUBECFG_JPATH=$PWD/ksonnet-lib
 


### PR DESCRIPTION
Last commit installs a kubecfg that gets ignored because it is not in
PATH nor executable (CI worked because the previous executable was in
the travis cache). Oops.