### PR TITLE
Fix invalid field `resourceName`

### DIFF
--- a/controller.jsonnet
+++ b/controller.jsonnet
@@ -114,7 +114,7 @@ local sealKeyRole = role("sealed-secrets-key-admin", namespace, [
   {
     apiGroups: [""],
     resources: ["secrets"],
-    resourceName: ["sealed-secrets-key"],
+    resourceNames: ["sealed-secrets-key"],
     verbs: ["get"],
   },
   {


### PR DESCRIPTION
`resourceName` should have been `resourceNames`.  Fixes #16

(Improvements to pre-release integration testing will be done separately)